### PR TITLE
Quote nodejs_global_packages to supress deprecation notices

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,4 +5,4 @@
 - include: nodejs.yml
 - name: Install global npm packages
   npm: global=yes name={{ item }} state=present
-  with_items: nodejs_global_packages
+  with_items: "{{ nodejs_global_packages }}"


### PR DESCRIPTION
Newer versions of Ansible (2.0+) gripe about bare words in the `with_items` keyword. This change supresses that notice by properly quoting and using expansion on `nodejs_global_packages`
